### PR TITLE
Cuprite tidyup

### DIFF
--- a/spec/system/first_system_spec.rb
+++ b/spec/system/first_system_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_helper"
 
-feature "visit admin", js: true do
+describe "Visit Admin", js: true do
   include UIComponentHelper
   include AuthenticationHelper
   include WebHelper

--- a/spec/system/support/better_rails_system_tests.rb
+++ b/spec/system/support/better_rails_system_tests.rb
@@ -1,5 +1,3 @@
-# spec/system/support/better_rails_system_tests.rb
-
 module BetterRailsSystemTests
   # Use our `Capybara.save_path` to store screenshots with other capybara artifacts
   # (Rails screenshots path is not configurable https://github.com/rails/rails/blob/49baf092439fc74fc3377b12e3334c3dd9d0752f/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L79)

--- a/spec/system/support/capybara_setup.rb
+++ b/spec/system/support/capybara_setup.rb
@@ -3,7 +3,7 @@
 # Usually, especially when using Selenium, developers tend to increase the max wait time.
 # With Cuprite, there is no need for that.
 # We use a Capybara default value here explicitly.
-Capybara.default_max_wait_time = 2
+Capybara.default_max_wait_time = 10
 
 # Normalize whitespaces when using `has_text?` and similar matchers,
 # i.e., ignore newlines, trailing spaces, etc.

--- a/spec/system/support/capybara_setup.rb
+++ b/spec/system/support/capybara_setup.rb
@@ -1,5 +1,3 @@
-# spec/system/support/capybara_setup.rb
-
 # Usually, especially when using Selenium, developers tend to increase the max wait time.
 # With Cuprite, there is no need for that.
 # We use a Capybara default value here explicitly.
@@ -13,8 +11,6 @@ Capybara.default_normalize_ws = true
 # Where to store system tests artifacts (e.g. screenshots, downloaded files, etc.).
 # It could be useful to be able to configure this path from the outside (e.g., on CI).
 Capybara.save_path = ENV.fetch("CAPYBARA_ARTIFACTS", "./tmp/capybara")
-
-# spec/system/support/capybara_setup.rb
 
 Capybara.singleton_class.prepend(Module.new do
   attr_accessor :last_used_session

--- a/spec/system/support/cuprite_helpers.rb
+++ b/spec/system/support/cuprite_helpers.rb
@@ -1,4 +1,18 @@
-module BetterRailsSystemTests
+# frozen_string_literal: true
+
+module CupriteHelpers
+  # Drop #pause anywhere in a test to stop the execution.
+  # Useful when you want to checkout the contents of a web page in the middle of a test
+  # running in a headful mode.
+  def pause
+    page.driver.pause
+  end
+
+  # Drop #debug anywhere in a test to open a Chrome inspector and pause the execution
+  def debug(*args)
+    page.driver.debug(*args)
+  end
+
   # Use our `Capybara.save_path` to store screenshots with other capybara artifacts
   # (Rails screenshots path is not configurable https://github.com/rails/rails/blob/49baf092439fc74fc3377b12e3334c3dd9d0752f/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb#L79)
   def absolute_image_path
@@ -11,24 +25,5 @@ module BetterRailsSystemTests
     return super unless Capybara.last_used_session
 
     Capybara.using_session(Capybara.last_used_session) { super }
-  end
-end
-
-RSpec.configure do |config|
-  config.include BetterRailsSystemTests, type: :system
-
-  # Make urls in mailers contain the correct server host.
-  # It's required for testing links in emails (e.g., via capybara-email).
-  config.around(:each, type: :system) do |ex|
-    was_host = Rails.application.default_url_options[:host]
-    Rails.application.default_url_options[:host] = Capybara.server_host
-    ex.run
-    Rails.application.default_url_options[:host] = was_host
-  end
-
-  # Make sure this hook runs before others
-  config.prepend_before(:each, type: :system) do
-    # Use JS driver always
-    driven_by Capybara.javascript_driver
   end
 end

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -8,6 +8,8 @@ Capybara.register_driver(:cuprite) do |app|
       browser_options: {},
       process_timeout: 20,
       timeout: 20,
+      # Don't load scripts from external sources, like google maps or stripe
+      url_whitelist: ["http://localhost", "http://0.0.0.0", "http://127.0.0.1"],
       inspector: true,
       headless: true
     }

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -1,23 +1,14 @@
-# spec/system/support/cuprite_setup.rb
-
-# First, load Cuprite Capybara integration
 require "capybara/cuprite"
 
-# Then, we need to register our driver to be able to use it later
-# with #driven_by method.
 Capybara.register_driver(:cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
     **{
       window_size: [1200, 800],
-      # See additional options for Dockerized environment in the respective section of this article
       browser_options: {},
-      # Increase Chrome startup wait time (required for stable CI builds)
       process_timeout: 20,
       timeout: 20,
-      # Enable debugging capabilities
       inspector: true,
-      # Allow running Chrome in a headful mode by setting HEADLESS env
       headless: true
     }
   )

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -13,7 +13,8 @@ Capybara.register_driver(:cuprite) do |app|
       # See additional options for Dockerized environment in the respective section of this article
       browser_options: {},
       # Increase Chrome startup wait time (required for stable CI builds)
-      process_timeout: 10,
+      process_timeout: 20,
+      timeout: 20,
       # Enable debugging capabilities
       inspector: true,
       # Allow running Chrome in a headful mode by setting HEADLESS env

--- a/spec/system/support/precompile_assets.rb
+++ b/spec/system/support/precompile_assets.rb
@@ -11,13 +11,11 @@ RSpec.configure do |config|
     # We can use webpack-dev-server for tests, too!
     # Useful if you working on a frontend code fixes and want to verify them via system tests.
     if Webpacker.dev_server.running?
-      $stdout.puts "\n⚙️  Webpack dev server is running! Skip assets compilation.\n"
       next
     else
-      $stdout.puts "\n🐢  Precompiling assets.\n"
+      $stdout.puts "\n Precompiling assets.\n"
 
-      # The code to run webpacker:compile Rake task
-      # ...
+      Webpacker.compile
     end
   end
 end


### PR DESCRIPTION
I added a few tweaks here so that the system test passes locally and did a bit of reorganising and tidying up of some of the original code from EvilMartians.

- Tweaked the timeout settings and stopped the browser loading external javascript (which was causing the test to be  a bit flaky when run locally)
- The `CupriteHelpers` module was defined inside the `cuprite_setup` file, so I extracted it to it's own file to keep `cuprite_setup` cleaner
- The `BetterRailsSystemTests` file was defining helper methods and adding important configuration. I moved the helper methods to `CupriteHelpers` and moved the important configuration to `cuprite_setup`, then deleted `BetterRailsSystemTests`.
- Removed some comments and tweaked the Webpacker compiling code